### PR TITLE
Use the latest godaddy-style && update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require('godaddy-test-tools')(gulp, {
 ```
 
 ... or `gulpfile.babel.js` if you are using ES6
-```
+```js
 import testTools from 'godaddy-test-tools';
 import gulp from 'gulp';
 
@@ -30,30 +30,58 @@ testTools(gulp, {
 
 ```
 
-Running `gulp help` will now show all the tasks and a description (if provided) for each of the tasks.
+Running `gulp help` will show all the tasks and a description (if provided) for each of the tasks.
 
 
 ### Options
+ - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `false`.
  - reporter: The reporter to use for mocha. default: `process.env.MOCHA_REPORTER || 'spec'`
  - sourceFiles: The source files that will be watched and code coverage. default: `lib/**/*.js`
  - unitTestFiles: A glob-able path(s) to all the unit test files. default: `test/unit/**/*.js`
  - integrationTestFiles: A glob-able path(s) to all the integration test files. defaut: `test/integration/**/*.js`
- - istanbul: Options for the istanbul reports. see: https://www.npmjs.com/package/gulp-istanbul#istanbul-writereports-opt
- - codeCoverageTestFiles: default `[options.unitTestFiles, options.integrationTestFiles]`
- - watchFiles: default: `[options.sourceFiles, options.unitTestFiles, options.integrationTestFiles]`
+ - istanbul: Options for [`gulp-istanbul`](https://www.npmjs.com/package/gulp-istanbul)
+ - watchFiles: default: `[sourceFiles, unitTestFiles, integrationTestFiles]`
  - lint:
     - filenameConvention: example: `{ type: (kebob, snake, camel), exclude: /regex/, files: ['lib/**/*.js', 'test/**/*.js'] }`
-    - files: a list of glob-able file paths to include in the lint checks. default: `['lib/**/*.js', 'test/**/*.js']`
-    - eslint: the argument passed to `gulp-eslint`. default: `require.resolve('godaddy-style/dist/.eslintrc')`. see: https://www.npmjs.com/package/gulp-eslint
-    - jshint: the argument passed to `gulp-jshint`. default: `require.resolve('godaddy-style/dist/.jshintrc')`. see: https://www.npmjs.com/package/gulp-jshint
-    - jscs: the argument passed to `gulp-jscs`. default: `require.resolve('godaddy-style/dist/.jscsrc')`. see: https://www.npmjs.com/package/gulp-jscs
-      - files: specify which files should be ran through jscs
+    - files: a list of glob-able file paths to include in the lint checks.
+        default:
+        ```js
+          [
+            sourceFiles,
+            unitTestFiles,
+            integrationTestFiles,
+            'index.js',
+            'main.js',
+            'gulpfile.js',
+            'gulpfile.babel.js',
+            'config/**/*.json',
+            'config/**/*.js',
+            'lib/**/*.json',
+            'test/**/*.json'
+          ]
+        ```
+    - eslint: the argument passed to [`gulp-eslint`](https://www.npmjs.com/package/gulp-eslint). default: `require.resolve('godaddy-style/dist/es5/.eslintrc')`.
+    - jshint: the argument passed to [`gulp-jshint`](https://www.npmjs.com/package/gulp-jshint). default: `require.resolve('godaddy-style/dist/.jshintrc')`.
+    - jscs: the argument passed to [`gulp-jscs`](https://www.npmjs.com/package/gulp-jscs). default: `require.resolve('godaddy-style/dist/es5/.jscsrc')`.
       - reporter: optional: [fail, failOnError]
+      - files: specify which files should be ran through jscs
+          default:
+          ```js
+            [
+              options.sourceFiles,
+              options.unitTestFiles,
+              options.integrationTestFiles,
+              'index.js',
+              'main.js',
+              'gulpfile.js',
+              'gulpfile.babel.js',
+              'config/**/*.js'
+            ]
+          ```
     - default: change the default linter from `eslint`
     - linters: change which linters are run when calling `gulp lint`
     - eslintFailOnError: failure after the first lint error is found.
-      default: fail after all files have been linted
- - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `false`.
+        default: fail after all files have been linted
 
 This tool defaults to a specific folder structure, but the options above
 allow for configuring that as needed:

--- a/lib/godaddy-style.js
+++ b/lib/godaddy-style.js
@@ -66,19 +66,11 @@ module.exports = function (gulp, options) {
   gulp.task('jscs', 'Run jscs', function () {
     return gulp.src(jscsConfig.files || options.files)
       .pipe(jscs(jscsConfig))
-      .pipe(through2.obj(function (file, enc, callback) {
-        writeFile(file.path, file._contents, callback);
-      }));
-  });
-
-  gulp.task('jscs-with-reporting', 'Run jscs and report on unfixable violations', function () {
-    return gulp.src(jscsConfig.files || options.files)
-      .pipe(jscs(jscsConfig))
       .pipe(jscs.reporter(jscsConfig.reporter))
       .pipe(through2.obj(function (file, enc, callback) {
         writeFile(file.path, file._contents, callback);
       }));
-  }, ['carriage-return-fix']);
+  });
 
   gulp.task('carriage-return-fix', 'Remove all \\r from the linted files', function () {
     return gulp.src(options.jscs && options.jscs.file || options.files)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "babel-eslint": "^5.0.0",
     "del": "^2.0.2",
-    "godaddy-style": "^2.0.3",
+    "godaddy-style": "^3.0.0",
     "gulp-eslint": "^2.0.0",
     "gulp-help": "^1.6.1",
     "gulp-istanbul": "^0.10.0",


### PR DESCRIPTION
- Adds JSCS reporting without failure by default and removes JSCS task
  that is now redundant
