### PR TITLE
Add support for istanbul enforceThresholds.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,8 @@ module.exports = function (gulp, options) {
     integrationTestFiles: INTEGRATION_FILES,
     base: 'test',
     istanbul: {
-      includeUntested: true
+      includeUntested: true,
+      thresholds: {}
     },
     es6: false,
     lint: {
@@ -167,6 +168,7 @@ module.exports = function (gulp, options) {
             reportOpts: { dir: './build/coverage' },
             reporters: ['lcov', 'json', 'text', 'text-summary', 'cobertura']
           })))
+          .pipe(istanbul.enforceThresholds(options.istanbul))
           .on('error', function (err) {
             notify({
               title: 'Istanbul test error!',


### PR DESCRIPTION
This PR adds support for specifying code coverage thresholds using `godaddy-test-tools`. Example usage:

``` javascript
import testTools from 'godaddy-test-tools';
import gulp from 'gulp';

testTools(gulp, {
  es6: true,
  sourceFiles: 'src/**/*.js',
  mocha: {
    reporter: 'mocha-multi',
    reporterOptions: {
      'mocha-junit-reporter': '-',
      'spec': '-'
    }
  },
  istanbul: {
    thresholds: {
      global: {
        statements: 75,
        branches: 80,
        functions: 70,
        lines: 20
      }
    }
  }
});
```

Supporting documentation for istanbul thresholds here: https://www.npmjs.com/package/gulp-istanbul#thresholds
