### PR TITLE
Add a standalone coverage task

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,9 +95,11 @@ module.exports = function (gulp, options) {
     runWithDependencyProcess(runMocha, _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]), cb);
   });
 
-  gulp.task('test', 'Run all the tests with code coverage', ['lint'], function (cb) {
+  gulp.task('coverage', 'Run all the tests with code coverage', function (cb) {
     runWithDependencyProcess(runIstanbul, _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]), cb);
   });
+
+  gulp.task('test', 'Run all the tests with linting and code coverage', ['lint', 'coverage']);
 
   var description = 'Watch files for changes and invoke mocha when one changes.';
   gulp.task('watch', description, function () {


### PR DESCRIPTION
Allow coverage report to be run independently of linting by using `gulp coverage`.
