### PR TITLE
Remove junit tasks for junit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Running `gulp help` will show all the tasks and a description (if provided) for 
 
 ### Options
  - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `true`.
- - junit: Use junit reporting for the currently run task and output to the specified file (Currently supported by unit, integration,
-   eslint and respective coverage tasks).
+ - junit: Use junit reporting for the currently run task and output to the specified file. If has a string value, it will be interpretted
+   as the file where the results should be written, if simply present, the argument will trigger the junit default file at
+   `./build/test/*-results.xml`. This options is currently supported by unit, integration, eslint and respective coverage tasks.
  - allowUnhandledRejections: The test tools will not throw an exception when a promise has an unresolved rejection. Defaults to `false`.
  - sourceFiles: The source files that will be watched and code coverage. default: `lib/**/*.js`
  - unitTestFiles: A glob-able path(s) to all the unit test files. default: `test/unit/**/*.js`

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Running `gulp help` will show all the tasks and a description (if provided) for 
 
 
 ### Options
- - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `false`.
+ - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `true`.
+ - junit: Use junit reporting for the currently run task and output to the specified file (Currently supported by unit, integration,
+   eslint and respective coverage tasks).
  - allowUnhandledRejections: The test tools will not throw an exception when a promise has an unresolved rejection. Defaults to `false`.
- - reporter: The reporter to use for mocha. default: `process.env.MOCHA_REPORTER || 'spec'`
  - sourceFiles: The source files that will be watched and code coverage. default: `lib/**/*.js`
  - unitTestFiles: A glob-able path(s) to all the unit test files. default: `test/unit/**/*.js`
  - integrationTestFiles: A glob-able path(s) to all the integration test files. defaut: `test/integration/**/*.js`

--- a/lib/godaddy-style.js
+++ b/lib/godaddy-style.js
@@ -1,6 +1,7 @@
 /* eslint no-console: 0, no-sync: 0 */
 'use strict';
 
+var argv = require('yargs').argv;
 var _ = require('lodash');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
@@ -47,6 +48,8 @@ module.exports = function (gulp, options) {
   });
   jscsConfig.fix = jscsConfig.fix !== false;
 
+  junitOutput(options);
+
   gulp.task('jshint', 'Lint the js files with jshint', function () {
     return gulp.src(options.files)
       .pipe(jshint(_.merge(loadLintConfig('jshint'), options.jshint)))
@@ -54,25 +57,13 @@ module.exports = function (gulp, options) {
       .pipe(jshintReporter);
   });
 
-  gulp.task('eslint-junit', 'Lint the js files with eslint and output junit results to file', function () {
-    var output = process.env.ESLINT_FILE || './build/test/eslint-results.xml';
-    var dir = path.dirname(output);
-    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
-    var baseConfigPath = require.resolve(options.es6 ? 'godaddy-style/dist/.eslintrc' : 'godaddy-style/dist/es5/.eslintrc');
-    var eslintOpts = _.merge({ baseConfig: baseConfigPath }, options.eslint);
-    return gulp.src(options.files)
-      .pipe(eslint(eslintOpts))
-      .pipe(eslint.format('junit', function (data) { fs.writeFile(output, data); }))
-      .pipe(options.eslintFailOnError ? eslint.failOnError() : eslint.failAfterError());
-  });
-
   gulp.task('eslint', 'Lint the js files with eslint', function () {
     var baseConfigPath = require.resolve(options.es6 ? 'godaddy-style/dist/.eslintrc' : 'godaddy-style/dist/es5/.eslintrc');
     var eslintOpts = _.merge({ baseConfig: baseConfigPath }, options.eslint);
     return gulp.src(options.files)
       .pipe(eslint(eslintOpts))
-      .pipe(eslint.format())
-      .pipe(options.eslintFailOnError ? eslint.failOnError() : eslint.failAfterError());
+      .pipe(eslint.format(eslintOpts.formatter, eslintOpts.formatterFunction))
+      .pipe(eslint[eslintOpts.fail || 'failAfterError']());
   });
 
   gulp.task('jscs', 'Run jscs', ['eslint'], function () {
@@ -127,6 +118,15 @@ module.exports = function (gulp, options) {
   });
 
   gulp.task('lint', 'Lint the js files', options.linters || [options.default || 'eslint', 'jscs']);
-  gulp.task('lint-junit', 'Lint the js files and output junit results', ['eslint-junit', 'jscs']);
 };
+
+function junitOutput(opts) {
+  if (argv.junit) {
+    var file = typeof argv.junit === 'string' ? argv.junit : (process.env.ESLINT_FILE || './build/test/eslint-results.xml');
+    var dir = path.dirname(file);
+    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
+    opts.eslint.formatter = 'junit';
+    opts.formatterFunction = function (data) { fs.writeFile(file, data); };
+  }
+}
 

--- a/lib/godaddy-style.js
+++ b/lib/godaddy-style.js
@@ -1,7 +1,6 @@
 /* eslint no-console: 0, no-sync: 0 */
 'use strict';
 
-var argv = require('yargs').argv;
 var _ = require('lodash');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
@@ -47,8 +46,6 @@ module.exports = function (gulp, options) {
     configPath: require.resolve(options.es6 ? 'godaddy-style/dist/.jscsrc' : 'godaddy-style/dist/es5/.jscsrc')
   });
   jscsConfig.fix = jscsConfig.fix !== false;
-
-  junitOutput(options);
 
   gulp.task('jshint', 'Lint the js files with jshint', function () {
     return gulp.src(options.files)
@@ -119,14 +116,4 @@ module.exports = function (gulp, options) {
 
   gulp.task('lint', 'Lint the js files', options.linters || [options.default || 'eslint', 'jscs']);
 };
-
-function junitOutput(opts) {
-  if (argv.junit) {
-    var file = typeof argv.junit === 'string' ? argv.junit : (process.env.ESLINT_FILE || './build/test/eslint-results.xml');
-    var dir = path.dirname(file);
-    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
-    opts.eslint.formatter = 'junit';
-    opts.formatterFunction = function (data) { fs.writeFile(file, data); };
-  }
-}
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,20 +28,23 @@ module.exports = function (gulp, options) {
   gulp = gulpHelp(gulp);
 
   options = _.defaultsDeep(options || {}, {
-    reporter: process.env.MOCHA_REPORTER || 'spec',
     sourceFiles: SOURCE_FILES,
     unitTestFiles: UNIT_FILES,
     integrationTestFiles: INTEGRATION_FILES,
-    base: 'test',
     istanbul: {
       includeUntested: true,
-      thresholds: {}
+      thresholds: {},
+      dir: './build/coverage',
+      reportOpts: { dir: './build/coverage' },
+      reporters: ['lcov', 'json', 'text', 'text-summary', 'cobertura']
     },
-    es6: false,
+    es6: true,
     lint: {
       jscs: {}
     },
-    mocha: {}
+    mocha: {
+      reporter: process.env.MOCHA_REPORTER || 'spec'
+    }
   });
 
   // allows command line arguments to modify the options object
@@ -51,6 +54,8 @@ module.exports = function (gulp, options) {
     if (name === '_' || name === '$0') return;
     options[name] = _.merge(options[name] || {}, value);
   });
+
+  junitOutput(options);
 
   if (!options.allowUnhandledRejections) {
     process.on('unhandledRejection', function (e) {
@@ -102,11 +107,6 @@ module.exports = function (gulp, options) {
     runWithDependencyProcess(runMocha, options.integrationTestFiles, cb);
   });
 
-  gulp.task('unit-coverage-junit', 'Run all the unit tests with code coverage', function (cb) {
-    junitOutput();
-    runIstanbul(options.unitTestFiles, cb);
-  });
-
   gulp.task('unit-coverage', 'Run all the unit tests with code coverage', function (cb) {
     runIstanbul(options.unitTestFiles, cb);
   });
@@ -119,14 +119,7 @@ module.exports = function (gulp, options) {
     runWithDependencyProcess(runMocha, _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]), cb);
   });
 
-  gulp.task('test-junit', 'Run all the tests with code coverage and output the results as JUNIT. (Specify ', ['lint-junit'], function (cb) {
-    junitOutput();
-    runWithDependencyProcess(runIstanbul, _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]), cb);
-  });
-
-  gulp.task('test', 'Run all the tests with code coverage', ['lint'], function (cb) {
-    runWithDependencyProcess(runIstanbul, _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]), cb);
-  });
+  gulp.task('test', 'Run all the tests with code coverage', ['lint', 'unit-coverage', 'integration-coverage']);
 
   var description = 'Watch files for changes and invoke mocha when one changes.';
   gulp.task('watch', description, function () {
@@ -162,10 +155,7 @@ module.exports = function (gulp, options) {
     var done = once(cb || function () {});
 
     return gulp.src(files, options)
-      .pipe(mocha(_.merge({
-        reporter: options.reporter,
-        bail: Boolean(argv.bail)
-      }, options.mocha)))
+      .pipe(mocha(options.mocha))
       .on('error', function (err) {
         notify({
           title: 'Test error!',
@@ -195,11 +185,7 @@ module.exports = function (gulp, options) {
         runMocha(files, function (err) {
           if (err) return done(err);
         })
-        .pipe(istanbul.writeReports(_.defaults(options.istanbulReports || {}, {
-          dir: './build/coverage',
-          reportOpts: { dir: './build/coverage' },
-          reporters: ['lcov', 'json', 'text', 'text-summary', 'cobertura']
-        })))
+        .pipe(istanbul.writeReports(options.istanbul))
         .pipe(istanbul.enforceThresholds(options.istanbul))
         .on('error', function (err) {
           notify({
@@ -270,14 +256,6 @@ module.exports = function (gulp, options) {
       notify({ title: opts.name, message: 'Exited' });
     });
   }
-
-  function junitOutput() {
-    var file = process.env.MOCHA_FILE || './build/test/test-results.xml';
-    var dir = path.dirname(file);
-    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
-    options.reporter = 'mocha-junit-reporter';
-    options.mocha.reporterOptions = { mochaFile: file }
-  }
 };
 
 function notify(options) {
@@ -286,3 +264,14 @@ function notify(options) {
     notifier.notify(options);
   }
 }
+
+function junitOutput(opts) {
+  if (argv.junit) {
+    var file = typeof argv.junit === 'string' ? argv.junit : (process.env.MOCHA_FILE || './build/test/test-results.xml');
+    var dir = path.dirname(file);
+    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
+    opts.mocha.reporter = 'mocha-junit-reporter';
+    opts.mocha.reporterOptions = { mochaFile: file };
+  }
+}
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,8 @@ module.exports = function (gulp, options) {
     }
   });
 
+  junitOutput(options);
+
   // allows command line arguments to modify the options object
   // ex: gulp test --mocha.grep @production-only --mocha.invert
   // -- options.mocha == { grep: '@production-only', invert: true }
@@ -54,8 +56,6 @@ module.exports = function (gulp, options) {
     if (name === '_' || name === '$0') return;
     options[name] = _.merge(options[name] || {}, value);
   });
-
-  junitOutput(options);
 
   if (!options.allowUnhandledRejections) {
     process.on('unhandledRejection', function (e) {
@@ -267,11 +267,19 @@ function notify(options) {
 
 function junitOutput(opts) {
   if (argv.junit) {
+    // handle the test output
     var file = typeof argv.junit === 'string' ? argv.junit : (process.env.MOCHA_FILE || './build/test/test-results.xml');
     var dir = path.dirname(file);
     if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
     opts.mocha.reporter = 'mocha-junit-reporter';
     opts.mocha.reporterOptions = { mochaFile: file };
+
+    // set the eslint junit handling as well
+    file = typeof argv.junit === 'string' ? argv.junit : (process.env.ESLINT_FILE || './build/test/eslint-results.xml');
+    dir = path.dirname(file);
+    if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
+    opts.eslint.formatter = 'junit';
+    opts.eslint.formatterFunction = function (data) { fs.writeFile(file, data); };
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ module.exports = function (gulp, options) {
     },
     es6: true,
     lint: {
+      eslint: {},
       jscs: {}
     },
     mocha: {
@@ -278,8 +279,8 @@ function junitOutput(opts) {
     file = typeof argv.junit === 'string' ? argv.junit : (process.env.ESLINT_FILE || './build/test/eslint-results.xml');
     dir = path.dirname(file);
     if (!fs.existsSync(dir)) mkdirp.sync(dir, 0o777);
-    opts.eslint.formatter = 'junit';
-    opts.eslint.formatterFunction = function (data) { fs.writeFile(file, data); };
+    opts.lint.eslint.formatter = 'junit';
+    opts.lint.eslint.formatterFunction = function (data) { fs.writeFile(file, data); };
   }
 }
 


### PR DESCRIPTION
Also, cleans up `reporter` and `istanbulReports` in favor of existing
options and defaults `es6` to true.

This will be a major version bump because of breaking changes.
