### PR TITLE
Mocha doesn't need the file contents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,7 +158,7 @@ module.exports = function (gulp, options) {
   function runMocha(files, cb) {
     var done = once(cb || function () {});
 
-    return gulp.src(files, options)
+    return gulp.src(files, _.merge({read: false}, options))
       .pipe(mocha(options.mocha))
       .on('error', function (err) {
         notify({


### PR DESCRIPTION
Setting `read` to false because mocha doesn't need the files contents.
This should make `gulp unit` start faster.
See: https://github.com/sindresorhus/gulp-mocha#usage