### PR TITLE
Removing godaddy/javascript dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "root": true,
+  "extends": "godaddy",
   "rules": {
     "strict": 0
   }

--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ you pass the `--no-notify` option.
 
 9.x.x:
 * No `baseConfig` is defined by default anymore.
-* `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` buy default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
+* `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` by default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 npm install --save-dev godaddy-test-tools
 ```
 
+Also install one of the configuration packages part of the https://github.com/godaddy/javascript project.
+Choosing the configuration package depends on what packages your project will use.
+
 ... add the package to your `gulpfile.js`
 ```js
 'use strict';

--- a/README.md
+++ b/README.md
@@ -103,4 +103,5 @@ you pass the `--no-notify` option.
 9.x.x:
 * No `baseConfig` is defined by default anymore.
 * `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` by default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
+* Removing `jscs` and `jshint` tasks. They were already not doing anything.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ you pass the `--no-notify` option.
 
 9.x.x:
 * No `baseConfig` is defined by default anymore. Please extend the appropriate `eslint-config` package on your `eslintrc` file.
-* `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` by default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
+* `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` by default. If you want to keep the previous behavior, you can pass the `{ istanbul: { instrumenter: null } }` as option.
 * Removing `jscs` and `jshint` tasks. They were already not doing anything.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Running `gulp help` will show all the tasks and a description (if provided) for 
 
 
 ### Options
- - es6: Specifies that your code is written in ES6 (+ JSX). You must also name your gulpfile `gulpfile.babel.js`. Defaults to `true`.
  - junit: Use junit reporting for the currently run task and output to the specified file. If has a string value, it will be interpretted
    as the file where the results should be written, if simply present, the argument will trigger the junit default file at
    `./build/test/*-results.xml`. This options is currently supported by unit, integration, eslint and respective coverage tasks.
@@ -98,3 +97,10 @@ Additionally, this project will send system notifications through
 [`node-notifier`](https://www.npmjs.com/package/node-notifier) when
 there are errors in your tests and when tests have run successfully unless
 you pass the `--no-notify` option.
+
+### Changelog
+
+9.x.x:
+* No `baseConfig` is defined by default anymore.
+* `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` buy default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
+

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ you pass the `--no-notify` option.
 ### Changelog
 
 9.x.x:
-* No `baseConfig` is defined by default anymore.
+* No `baseConfig` is defined by default anymore. Please extend the appropriate `eslint-config` package on your `eslintrc` file.
 * `es6` option was removed and became the default. This also means that the `istanbul.instrumenter` option became the `isparta.Instrumenter` by default. If you want to keep the previous behavior, you can pass the `{ instanbul: { instrumenter: null } }` as option.
 * Removing `jscs` and `jshint` tasks. They were already not doing anything.
 

--- a/lib/godaddy-style.js
+++ b/lib/godaddy-style.js
@@ -21,15 +21,7 @@ module.exports = function (gulp, options) {
   });
 
   gulp.task('eslint', 'Lint the js files with eslint', function () {
-    var version = !options.es6 ? '-es5' : '';
-    var eslintOpts = _.defaultsDeep({}, options.eslint, {
-      baseConfig: {
-        extends: [
-          'godaddy' + version,
-          'godaddy-react'
-        ].concat(options.eslint.extends || [])
-      }
-    });
+    var eslintOpts = _.defaultsDeep({}, options.eslint);
     return gulp.src(options.files)
       .pipe(eslint(eslintOpts))
       .pipe(through2.obj(function (file, enc, callback) {

--- a/lib/godaddy-style.js
+++ b/lib/godaddy-style.js
@@ -16,10 +16,6 @@ var FILENAME_CONVENTIONS = {
 module.exports = function (gulp, options) {
   options = options || {};
 
-  gulp.task('jshint', 'Lint the js files with jshint', function () {
-    console.log('jshint is deprecated');
-  });
-
   gulp.task('eslint', 'Lint the js files with eslint', function () {
     var eslintOpts = _.defaultsDeep({}, options.eslint);
     return gulp.src(options.files)
@@ -32,10 +28,6 @@ module.exports = function (gulp, options) {
       }))
       .pipe(eslint.format(eslintOpts.formatter, eslintOpts.formatterFunction))
       .pipe(eslint[eslintOpts.fail || 'failAfterError']());
-  });
-
-  gulp.task('jscs', 'Run jscs', ['eslint'], function () {
-    console.log('jscs is deprecated. Please use eslint.');
   });
 
   gulp.task('carriage-return-fix', 'Remove all \\r from the linted files', function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,9 +37,9 @@ module.exports = function (gulp, options) {
       thresholds: {},
       dir: './build/coverage',
       reportOpts: { dir: './build/coverage' },
-      reporters: ['lcov', 'json', 'text', 'text-summary', 'cobertura']
+      reporters: ['lcov', 'json', 'text', 'text-summary', 'cobertura'],
+      instrumenter: isparta.Instrumenter
     },
-    es6: true,
     lint: {
       eslint: {}
     },
@@ -68,11 +68,6 @@ module.exports = function (gulp, options) {
       // no swallowed Promise errors
       throw e;
     });
-  }
-
-  if (options.es6) {
-    options.lint.es6 = true;
-    options.istanbul.instrumenter = isparta.Instrumenter;
   }
 
   var lintOptions = options.lint;

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^4.4.1",
-    "gulp": "^3.9.0",
-    "eslint-config-godaddy": "^1.0.0",
+    "eslint-config-godaddy": "^2.0.0",
     "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.9.0"
+    "eslint-plugin-mocha": "^4.9.0",
+    "gulp": "^3.9.0"
   },
   "peerDependencies": {
     "gulp": "*"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "eslint": "^4.4.1",
-    "gulp": "^3.9.0"
+    "gulp": "^3.9.0",
+    "eslint-config-godaddy": "^1.0.0",
+    "eslint-plugin-json": "^1.2.0",
+    "eslint-plugin-mocha": "^4.9.0"
   },
   "peerDependencies": {
     "gulp": "*"

--- a/package.json
+++ b/package.json
@@ -17,21 +17,15 @@
   "author": "GoDaddy",
   "license": "MIT",
   "devDependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint": "^4.4.1",
     "gulp": "^3.9.0"
   },
   "peerDependencies": {
     "gulp": "*"
   },
   "dependencies": {
-    "babel-eslint": "^7.1.1",
     "del": "^2.0.2",
-    "eslint": "^3.15.0",
-    "eslint-config-godaddy": "^1.0.0",
-    "eslint-config-godaddy-es5": "^1.0.0",
-    "eslint-config-godaddy-react": "^1.0.0",
-    "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-mocha": "^4.9.0",
-    "eslint-plugin-react": "^6.9.0",
     "gulp-eslint": "^4.0.0",
     "gulp-help": "^1.6.1",
     "gulp-istanbul": "^1.1.1",


### PR DESCRIPTION
With the addition of the new package `eslint-config-godaddy-react-flow` to the https://github.com/godaddy/javascript project, it seems clear that having those projects as dependencies of `godaddy-test-tools` is not what we should be doing.

Having a project with `godaddy-test-tools` and `eslint-config-godaddy-react-flow` is impossible at this point because this project is requiring `eslint@^3.15.0` while `eslint-config-godaddy-react-flow` requires eslint 4. This problem could be avoided if the godaddy/javascript packages weren't dependencies of this project.

My suggestion is to remove them as being dependencies and inform that this package should be installed with one of those packages on the `README`.

cc @samshull 