### PR TITLE
Downgrade gulp-mocha because gulp-istanbul doesn't work with newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-eslint": "^5.0.0",
     "gulp-help": "^1.6.1",
     "gulp-istanbul": "^1.1.3",
-    "gulp-mocha": "^6.0.0",
+    "gulp-mocha": "^3.0.0",
     "gulp-sonar": "^3.0.0",
     "gulp-util": "^3.0.7",
     "isparta": "^4.1.0",


### PR DESCRIPTION
See https://github.com/SBoudrias/gulp-istanbul/issues/115 as mentioned in the gulp-istanbul README