### PR TITLE
Remove promise rejection while watching runMocha

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,7 +108,7 @@ module.exports = function (gulp, options) {
     var watcher = gulp.watch(options.watchFiles || watchFiles);
     var testFiles = _.flattenDeep([options.unitTestFiles, options.integrationTestFiles]);
 
-    runMocha(testFiles);
+    runMocha(testFiles, true);
 
     watcher.on('change', function (event) {
       notify({
@@ -116,7 +116,7 @@ module.exports = function (gulp, options) {
         message: 'Running mocha...'
       });
 
-      runMocha(testFiles);
+      runMocha(testFiles, true);
     });
   }
 
@@ -137,7 +137,7 @@ module.exports = function (gulp, options) {
   full.displayName = 'full';
   full.description = 'Run the build and sonar tasks';
 
-  function runMocha(files) {
+  function runMocha(files, isWatching) {
     if (!Array.isArray(files)) {
       files = [files];
     }
@@ -170,6 +170,9 @@ module.exports = function (gulp, options) {
             message: 'There was an error in the tests for ' + fileNames + '.',
             icon: mochaIcon
           });
+          if (isWatching) {
+            return void resolve();
+          }
           reject(new Error('The tests had an error'));
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "godaddy-test-tools",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "description": "Gulp tools for simplifying the testing of node libraries with mocha and istanbul",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When running tests with `runMocha`, I realized that when we a test fails, the watch command exits because of the error being thrown, defeating the watch command purpose. To resolve that, I changed it with a simple flag to not return that error while watch is running.